### PR TITLE
Containerization + ColabDesign import fix + docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@ __pycache__/
 **/.DS_Store
 *.pyc
 *.csv
-*.sh
 *.gif
 *.egg-info/
 *.pt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,106 @@
+FROM nvidia/cuda:12.4.1-cudnn9-runtime-ubuntu22.04
+
+# Germinal GPU-enabled container
+# - Includes micromamba-managed conda env from environment.yml
+# - Installs CUDA-enabled JAX, PyTorch, Torch Geometric, Chai, IgLM
+# - Installs project and ColabDesign in editable mode
+#
+# Notes:
+# - PyRosetta is installed automatically via conda
+# - AlphaFold-Multimer parameters are downloaded into /workspace/params during build
+
+ARG DEBIAN_FRONTEND=noninteractive
+SHELL ["/bin/bash", "-lc"]
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    git \
+    aria2 \
+    ffmpeg \
+    procps \
+  && rm -rf /var/lib/apt/lists/*
+
+# Install micromamba
+ENV MAMBA_ROOT_PREFIX=/opt/conda
+ENV MAMBA_NO_BANNER=1
+RUN curl -Ls https://micro.mamba.pm/api/micromamba/linux-64/latest | \
+    tar -xvj -C /usr/local/bin --strip-components=1 bin/micromamba
+
+# Create conda environment from environment.yml
+WORKDIR /workspace
+COPY environment.yml /tmp/environment.yml
+RUN micromamba create -y -n germinal -f /tmp/environment.yml && micromamba clean -a -y
+
+# Make the env the default for subsequent RUN/CMD
+ENV PATH=/opt/conda/envs/germinal/bin:${PATH}
+ENV PIP_NO_CACHE_DIR=1
+
+# Install PyRosetta via conda (Rosetta Commons channel)
+ARG PYROSETTA_CHANNEL=https://conda.rosettacommons.org
+RUN micromamba install -y -n germinal -c "${PYROSETTA_CHANNEL}" pyrosetta && micromamba clean -a -y
+
+# Install JAX (GPU or CPU), PyTorch (GPU or CPU), Torch Geometric, and additional deps
+# You can build a CPU-only image with: 
+#   docker build --build-arg JAX_CUDA=false --build-arg CUDA_SUFFIX=cpu \
+#                --build-arg TORCH_INDEX_URL=https://download.pytorch.org/whl/cpu -t germinal:cpu .
+
+ARG TORCH_VERSION=2.6.0
+ARG TORCHVISION_VERSION=0.21.0
+ARG TORCHAUDIO_VERSION=2.6.0
+ARG CUDA_SUFFIX=cu124
+ARG TORCH_INDEX_URL=https://download.pytorch.org/whl/${CUDA_SUFFIX}
+ARG JAX_CUDA=true
+
+RUN set -euxo pipefail; \
+  python -m pip install --upgrade pip wheel setuptools; \
+  if [ "${JAX_CUDA}" = "true" ]; then \
+    python -m pip install "jax[cuda12_pip]==0.5.3" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html; \
+  else \
+    python -m pip install "jax==0.5.3"; \
+  fi; \
+  python -m pip install --index-url "${TORCH_INDEX_URL}" \
+    torch=="${TORCH_VERSION}" \
+    torchvision=="${TORCHVISION_VERSION}" \
+    torchaudio=="${TORCHAUDIO_VERSION}"; \
+  if [ "${JAX_CUDA}" = "true" ]; then \
+    PYG_URL="https://data.pyg.org/whl/torch-${TORCH_VERSION}%2B${CUDA_SUFFIX}.html"; \
+  else \
+    PYG_URL="https://data.pyg.org/whl/torch-${TORCH_VERSION}+cpu.html"; \
+  fi; \
+  python -m pip install "torch_geometric==2.6.*" -f "${PYG_URL}"; \
+  python -m pip install \
+    chex dm-haiku==0.0.13 dm-tree joblib ml-collections immutabledict optax \
+    pandas matplotlib numpy biopython scipy seaborn tqdm py3dmol colabfold \
+    iglm chai-lab==0.6.1 torchtyping==0.1.5; \
+  true
+
+# Install ColabDesign (editable)
+COPY colabdesign /workspace/colabdesign
+RUN python -m pip install -e /workspace/colabdesign
+
+# Copy repo and install Germinal (editable)
+COPY . /workspace
+RUN python -m pip install -e .
+
+# Create mount points for data/outputs
+RUN mkdir -p /workspace/params /workspace/pdbs /workspace/runs
+
+# Download AlphaFold-Multimer parameters into the image
+RUN set -euxo pipefail; \
+  cd /workspace/params; \
+  aria2c -q -x 16 https://storage.googleapis.com/alphafold/alphafold_params_2022-12-06.tar; \
+  tar -xf alphafold_params_2022-12-06.tar -C /workspace/params; \
+  rm -f alphafold_params_2022-12-06.tar; \
+  chmod -R a+rX /workspace/params
+
+# Useful environment variables
+ENV PYTHONUNBUFFERED=1 \
+    MPLBACKEND=Agg \
+    HYDRA_FULL_ERROR=1
+
+# Always run inside the conda env
+ENTRYPOINT ["micromamba", "run", "-n", "germinal", "--no-capture-output"]
+CMD ["bash"]
+
+

--- a/README.md
+++ b/README.md
@@ -240,7 +240,19 @@ interface_shape_comp: {'value': 0.6, 'operator': '>'}
 <!-- TOC --><a name="container"></a>
 ## Container (Docker/Compose)
 
-Run Germinal without a local install using the provided Dockerfile and docker-compose.yml. This is the recommended way to get a reproducible environment, including CUDA-enabled JAX and PyTorch. The container automatically installs PyRosetta and downloads AlphaFold-Multimer parameters.
+See `container-use.md` for full Docker/Compose guidance, including GPU prerequisites, mounts, and run patterns. Quick start:
+
+```bash
+docker build -t germinal:latest .
+
+docker run --rm -it --gpus all \
+  --shm-size=16g --ipc=host \
+  --ulimit nofile=65536:65536 \
+  -v "$PWD/pdbs:/workspace/pdbs" \
+  -v "$PWD/runs:/workspace/runs" \
+  -w /workspace germinal:latest python run_germinal.py \
+  project_dir=/workspace/runs results_dir=. experiment_name=germinal_run
+```
 
 ### Prerequisites
 
@@ -252,7 +264,7 @@ Run Germinal without a local install using the provided Dockerfile and docker-co
 Verify GPU access for containers:
 
 ```bash
-docker run --rm --gpus all nvidia/cuda:12.4.1-cudnn9-runtime-ubuntu22.04 nvidia-smi
+docker run --rm --gpus all nvidia/cuda:12.4.1-cudnn-runtime-ubuntu22.04 nvidia-smi
 ```
 
 ### Build the image
@@ -277,11 +289,12 @@ Ensure these directories exist locally before running (for mounting outputs and 
 mkdir -p params pdbs runs
 ```
 
-### Run with docker run
+### Run with docker run (quick starts)
 
 ```bash
 docker run --rm -it --gpus all \
   --shm-size=16g --ipc=host \
+  --ulimit nofile=65536:65536 \
   -v "$PWD/pdbs:/workspace/pdbs" \
   -v "$PWD/runs:/workspace/runs" \
   -w /workspace germinal:latest bash
@@ -325,6 +338,26 @@ docker compose run --rm germinal python run_germinal.py \
   target=pdl1 \
   experiment_name=my_experiment \
   max_trajectories=100
+```
+
+### One-liner docker run commands (no shell)
+
+Run defaults (VHH/PD-L1) without opening a shell (outputs will appear in ./runs on host):
+
+```bash
+docker run --rm -it --gpus all --ipc=host --shm-size=16g \
+  --ulimit nofile=65536:65536 \
+  -v "$PWD/pdbs:/workspace/pdbs" -v "$PWD/runs:/workspace/runs" \
+  -w /workspace germinal:latest python run_germinal.py
+```
+
+Run scFv defaults (outputs will appear in ./runs on host):
+
+```bash
+docker run --rm -it --gpus all --ipc=host --shm-size=16g \
+  --ulimit nofile=65536:65536 \
+  -v "$PWD/pdbs:/workspace/pdbs" -v "$PWD/runs:/workspace/runs" \
+  -w /workspace germinal:latest python run_germinal.py run=scfv
 ```
 
 <!-- TOC --><a name="output-format"></a>

--- a/colabdesign/__init__.py
+++ b/colabdesign/__init__.py
@@ -1,7 +1,7 @@
 import os as _os
 from pkgutil import extend_path as _extend_path
 
-# Make this package aggregate the inner implementation directory for imports
+# Aggregate inner implementation directory for imports
 __path__ = _extend_path(__path__, __name__)  # type: ignore[name-defined]
 _inner = _os.path.join(_os.path.dirname(__file__), 'colabdesign')
 if _inner not in __path__:

--- a/container-use.md
+++ b/container-use.md
@@ -1,0 +1,147 @@
+# Germinal Container Usage
+
+This document describes running Germinal via Docker or Docker Compose, including GPU prerequisites, volume mounts, and common run patterns.
+
+## Prerequisites
+
+- Docker 24+
+- NVIDIA GPU with a recent driver (CUDA 12+ recommended)
+- NVIDIA Container Toolkit installed and configured
+  - See `https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html`
+
+Verify GPU access for containers:
+
+```bash
+docker run --rm --gpus all nvidia/cuda:12.4.1-cudnn-runtime-ubuntu22.04 nvidia-smi
+```
+
+## Build the Image
+
+```bash
+# From repo root
+docker build -t germinal:latest .
+
+# Or with Compose (uses docker-compose.yml)
+docker compose build
+```
+
+## Volumes and Data Locations
+
+- `/workspace/params` – AlphaFold-Multimer params (baked into the image by default)
+- `/workspace/pdbs` – Input PDBs
+- `/workspace/runs` – Outputs (mount to your host to persist)
+
+Create host dirs as needed:
+
+```bash
+mkdir -p pdbs runs
+```
+
+## Recommended Run Pattern
+
+Decide your host input/output locations, then mount them explicitly.
+
+- Host input PDB: `/abs/path/to/your_target.pdb`
+- Host output dir: `/abs/path/to/run_outputs`
+- Settings: use repo defaults inside the container or mount your own configs
+
+### 1) Use repository defaults for settings (inside container), mount only outputs
+
+```bash
+mkdir -p /abs/path/to/run_outputs
+
+# Default VHH + PD-L1 + default filters
+# Outputs go to /abs/path/to/run_outputs/germinal_run
+
+docker run --gpus all --rm -it \
+  --ulimit nofile=65536:65536 \
+  -v /abs/path/to/run_outputs:/workspace/runs \
+  -v "$PWD/pdbs:/workspace/pdbs:ro" \
+  -w /workspace germinal:latest \
+  python run_germinal.py project_dir=/workspace/runs results_dir=. experiment_name=germinal_run
+```
+
+scFv variant:
+
+```bash
+docker run --gpus all --rm -it \
+  --ulimit nofile=65536:65536 \
+  -v /abs/path/to/run_outputs:/workspace/runs \
+  -v "$PWD/pdbs:/workspace/pdbs:ro" \
+  -w /workspace germinal:latest \
+  python run_germinal.py run=scfv project_dir=/workspace/runs results_dir=. experiment_name=germinal_run
+```
+
+### 2) Mount a custom target YAML and input PDB from the host
+
+```bash
+mkdir -p /abs/path/to/run_outputs
+
+docker run --gpus all --rm -it \
+  --ulimit nofile=65536:65536 \
+  -v /abs/path/to/run_outputs:/workspace/runs \
+  -v /abs/path/to/my_target.yaml:/workspace/configs/target/my_target.yaml:ro \
+  -v /abs/path/to/your_target.pdb:/workspace/pdbs/your_target.pdb:ro \
+  -w /workspace germinal:latest \
+  python run_germinal.py target=my_target project_dir=/workspace/runs results_dir=. experiment_name=germinal_run
+```
+
+### 3) Mount custom filter/run settings too
+
+```bash
+docker run --gpus all --rm -it \
+  --ulimit nofile=65536:65536 \
+  -v /abs/path/to/run_outputs:/workspace/runs \
+  -v /abs/path/to/my_target.yaml:/workspace/configs/target/my_target.yaml:ro \
+  -v /abs/path/to/my_initial.yaml:/workspace/configs/filter/initial/custom.yaml:ro \
+  -v /abs/path/to/my_final.yaml:/workspace/configs/filter/final/custom.yaml:ro \
+  -v /abs/path/to/your_target.pdb:/workspace/pdbs/your_target.pdb:ro \
+  -w /workspace germinal:latest \
+  python run_germinal.py target=my_target filter.initial=custom filter.final=custom \
+    project_dir=/workspace/runs results_dir=. experiment_name=germinal_run
+```
+
+Notes:
+- Always mount your output directory to `/workspace/runs` and set `project_dir=/workspace/runs results_dir=. experiment_name=...` to route outputs to the mount.
+- Increase file descriptor limits with `--ulimit nofile=65536:65536` for heavy workloads.
+- The image includes AF-Multimer params in `/workspace/params` and PyRosetta via conda.
+
+## Quick Starts
+
+Interactive shell:
+
+```bash
+docker run --rm -it --gpus all \
+  --ulimit nofile=65536:65536 \
+  -v "$PWD/pdbs:/workspace/pdbs" \
+  -v "$PWD/runs:/workspace/runs" \
+  -w /workspace germinal:latest bash
+```
+
+Inside the container, run:
+
+```bash
+python run_germinal.py project_dir=/workspace/runs results_dir=. experiment_name=germinal_run
+```
+
+Compose run (no shell):
+
+```bash
+docker compose run --rm germinal python run_germinal.py \
+  project_dir=/workspace/runs results_dir=. experiment_name=germinal_run
+```
+
+Optional shared memory toggles:
+- If you encounter shared-memory or DataLoader/NCCL-related errors, add `--shm-size=16g` to `docker run` (sets host RAM allocation, not GPU VRAM), and/or `--ipc=host`.
+- For Compose, you can set `shm_size: 16gb` and/or `ipc: host` in `docker-compose.yml`.
+
+
+## Troubleshooting
+
+- No outputs under your host `runs` folder:
+  - Ensure you set `project_dir=/workspace/runs results_dir=. experiment_name=...` in the command.
+  - Verify your `-v /host/path:/workspace/runs` mount.
+- EntryPoint errors:
+  - Rebuild the image to pick up the latest entrypoint.
+- GPU not visible:
+  - Confirm `nvidia-smi` works on host and the NVIDIA Container Toolkit is installed.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,31 @@
+version: "3.9"
+
+services:
+  germinal:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        JAX_CUDA: "true"
+        CUDA_SUFFIX: "cu124"
+        TORCH_VERSION: "2.6.0"
+        TORCHVISION_VERSION: "0.21.0"
+        TORCHAUDIO_VERSION: "2.6.0"
+        TORCH_INDEX_URL: "https://download.pytorch.org/whl/cu124"
+    image: germinal:latest
+    gpus: all
+    ipc: host
+    shm_size: "16gb"
+    environment:
+      - HYDRA_FULL_ERROR=1
+      - MPLBACKEND=Agg
+      - PYTHONUNBUFFERED=1
+    volumes:
+      - ./pdbs:/workspace/pdbs
+      - ./runs:/workspace/runs
+    working_dir: /workspace
+    stdin_open: true
+    tty: true
+    command: bash
+
+

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Raise file descriptor limits if possible
+if command -v prlimit >/dev/null 2>&1; then
+  prlimit --pid $$ --nofile=65536:65536 || true
+fi
+
+# If no arguments provided, open a shell in the environment
+if [[ $# -eq 0 ]]; then
+  exec micromamba run -n germinal bash
+fi
+
+# Execute provided command via bash -lc inside the environment to avoid exec parsing issues
+cmd="$*"
+exec micromamba run -n germinal bash -lc "$cmd"
+
+


### PR DESCRIPTION
Problem: Environment was hard to reproduce across machines (GPU JAX/Torch, PyRosetta, AF params, colabfold dependency conflicts) and from colabdesign import mk_afdesign_model failed in some installs due to package resolution.

Changes Made:
- Added GPU-enabled Docker/Compose setup (installs JAX/Torch, PyRosetta; downloads AF-Multimer params) with clear mount points and quick-start docs.
- Added a minimal colabdesign/__init__.py to ensure mk_afdesign_model is importable from the vendored ColabDesign. This is required for both container use as well as conventional installation on the host.