### PR TITLE
Fix a bug when there is a return code for AF3

### DIFF
--- a/germinal/filters/af3.py
+++ b/germinal/filters/af3.py
@@ -516,7 +516,7 @@ def _run_af3(
     return_code = popen.wait()
 
     if return_code:
-        raise subprocess.CalledProcessError(return_code)
+        raise subprocess.CalledProcessError(return_code, run_cmds)
 
     pdb_path, scores = extract_structure_and_scores(output_dir, input_json["name"])
 


### PR DESCRIPTION
Line #519 of germinal/fiters/af3, CalledProcessError.__init__() missing a require arg 'cmd'.