### PR TITLE
Fix issue with the ipsae variable in jobs using Chai weights

### DIFF
--- a/germinal/filters/filter_utils.py
+++ b/germinal/filters/filter_utils.py
@@ -276,6 +276,7 @@ def build_filter_metrics(
     Returns:
         Dict[str, Any]: Confidence, interface, structural, biological, and sequence metrics
     """
+    ipsae = confidence_metrics["ipsae"]
     metrics = {
         # confidence
         "external_plddt": confidence_metrics["plddt"],
@@ -288,7 +289,7 @@ def build_filter_metrics(
         "external_plddt_binder": confidence_metrics["plddt_binder"],
         "external_chain_ptm": confidence_metrics["chain_ptm"],
         "external_binder_pae": confidence_metrics["binder_pae"],
-        "ipsae": confidence_metrics["ipsae"]["ipsae"],
+        "ipsae": None if ipsae is None else ipsae["ipsae"],
         # structure + interface
         "binder_near_hotspot": binder_near_hotspot,
         "clashes_unrelaxed": num_clashes_trajectory,
@@ -334,7 +335,7 @@ def build_filter_metrics(
         "binder_near_hotspot": binder_near_hotspot,
         # derived confidence
         "pdockq2": pdockq_metrics["pDockQ2"],
-        "ipsae_pdockq2": confidence_metrics["ipsae"]["pdockq2"],
+        "ipsae_pdockq2": None if ipsae is None else ipsae["pdockq2"],
         "lis_lis": lis_metrics["lis"],
         "lis_lia": lis_metrics["lia"],
         # secondary structure + framework metrics


### PR DESCRIPTION
Following from the issue reported [here](https://github.com/SantiagoMille/germinal/issues/48). It seems that a recent [commit](https://github.com/SantiagoMille/germinal/commit/7c980392016fbeba1b656d600f42856c80fae131) added functionality for ipsae metrics. These metrics are only emitted in runs that utilise AF3 (not Chai). The error results from the trying to index a None object on runs that use Chai. I have drafted this short PR which remedies this issue for me. I have verified that this code works locally when running `python run_germinal.py` with default parameters. 