### PR TITLE
Fix tokenizer for IgLM

### DIFF
--- a/colabdesign/colabdesign/iglm/model.py
+++ b/colabdesign/colabdesign/iglm/model.py
@@ -39,19 +39,11 @@ class CustomIgLM(nn.Module, IgLM):
         super().__init__()
         IgLM.__init__(self, model_name=model_name)
 
-        # transformers>=5 ignores `vocab_file=` for BertTokenizer(BertTokenizerFast) and loads a minimal vocab.
-        # This breaks IgLM, because we expect amino-acid tokens like "A" to exist.
+        from iglm.model.IgLM import VOCAB_FILE as IGLM_VOCAB_FILE
         try:
-            from iglm.model.IgLM import VOCAB_FILE as IGLM_VOCAB_FILE  # type: ignore
-            self.tokenizer = transformers.BertTokenizerFast(
-                vocab=IGLM_VOCAB_FILE,
-                do_lower_case=False,
-            )
-        except Exception as e:
-            raise RuntimeError(
-                f"Failed to override IgLM tokenizer using vocab file '{IGLM_VOCAB_FILE}'. "
-                "This is required for transformers==5.3.0 compatibility."
-            ) from e
+            self.tokenizer = transformers.BertTokenizerFast(vocab=IGLM_VOCAB_FILE, do_lower_case=False)
+        except TypeError:
+            self.tokenizer = transformers.BertTokenizerFast(vocab_file=IGLM_VOCAB_FILE, do_lower_case=False)
 
         if device is not None:
             self.device = device

--- a/colabdesign/colabdesign/iglm/model.py
+++ b/colabdesign/colabdesign/iglm/model.py
@@ -5,6 +5,7 @@ import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+import transformers
 from typing import Optional
 
 class CustomIgLM(nn.Module, IgLM):
@@ -37,6 +38,20 @@ class CustomIgLM(nn.Module, IgLM):
         """
         super().__init__()
         IgLM.__init__(self, model_name=model_name)
+
+        # transformers>=5 ignores `vocab_file=` for BertTokenizer(BertTokenizerFast) and loads a minimal vocab.
+        # This breaks IgLM, because we expect amino-acid tokens like "A" to exist.
+        try:
+            from iglm.model.IgLM import VOCAB_FILE as IGLM_VOCAB_FILE  # type: ignore
+            self.tokenizer = transformers.BertTokenizerFast(
+                vocab=IGLM_VOCAB_FILE,
+                do_lower_case=False,
+            )
+        except Exception as e:
+            raise RuntimeError(
+                f"Failed to override IgLM tokenizer using vocab file '{IGLM_VOCAB_FILE}'. "
+                "This is required for transformers==5.3.0 compatibility."
+            ) from e
 
         if device is not None:
             self.device = device


### PR DESCRIPTION
When installing using the `environment_setup.md` instructions, my environment ends up with `transformers==5.3.0` - `python run_germinal.py` fails with the error:

```
Error executing job with overrides: []
Traceback (most recent call last):
  File "/data/repos/germinal/run_germinal.py", line 94, in main
    design_output = germinal_design(
  File "/data/repos/germinal/germinal/design/design.py", line 144, in germinal_design
    af_model.prep_inputs(
  File "/data/repos/germinal/colabdesign/colabdesign/af/prep.py", line 335, in _prep_binder
    self.prep_iglm(lens, **kwargs)
  File "/data/repos/germinal/colabdesign/colabdesign/af/prep.py", line 48, in prep_iglm
    self.ablm_model = CustomIgLM(**iglm_kwargs)
  File "/data/repos/germinal/colabdesign/colabdesign/iglm/model.py", line 63, in __init__
    raise ValueError(f"Unrecognized amino acid token: {aa}")
ValueError: Unrecognized amino acid token: A
```

It appears this is because the IgLM model is not loading the correct vocab for its tokenizer. This PR ensures it explicitly uses the correct vocab. 

The upstream [IgLM environment](https://github.com/Graylab/IgLM/blob/main/environment.yml) pins transformers to 4.6.1, but Germinal dependencies pull in transformers 5.x - there have been API changes to tokenization in v5, and I suspect this is why IgLM broke. I've not tested the upstream IgLM in isolation.