### PR TITLE
Chai deep fix: stop mutating restraints source; expose inference params

### DIFF
--- a/germinal/filters/chai.py
+++ b/germinal/filters/chai.py
@@ -68,6 +68,9 @@ def run_chai(
     hotspot_residue = None,
     binder_chain = "B",
     target_len: int = None,
+    num_trunk_recycles: int = 3,
+    num_diffn_timesteps: int = 200,
+    use_esm_embeddings: bool = True,
 ):
     """
     Run Chai-1 structure prediction for antibody-target complex.
@@ -83,6 +86,12 @@ def run_chai(
         pdb (str): Path to PDB file containing the target protein structure.
         target_chain (str, optional): Chain ID of target protein. Defaults to 'A'.
         seed (int, optional): Random seed for reproducible predictions. Defaults to 0.
+        num_trunk_recycles (int, optional): Structure refinement cycles.
+            Defaults to 3.
+        num_diffn_timesteps (int, optional): Diffusion sampling steps.
+            Defaults to 200.
+        use_esm_embeddings (bool, optional): Use ESM language model embeddings.
+            Defaults to True.
 
     Returns:
         tuple: (structure_path, scores_dict) where:
@@ -137,10 +146,10 @@ def run_chai(
     candidates = run_inference(
         fasta_file=fasta_path,
         output_dir=output_dir,
-        num_trunk_recycles=3,  # Number of structure refinement cycles
-        num_diffn_timesteps=200,  # Diffusion sampling steps
-        device="cuda:0",  # GPU device for acceleration
-        use_esm_embeddings=True,  # Use ESM language model embeddings
+        num_trunk_recycles=num_trunk_recycles,
+        num_diffn_timesteps=num_diffn_timesteps,
+        device="cuda:0",  # Index 0 of CUDA_VISIBLE_DEVICES
+        use_esm_embeddings=use_esm_embeddings,
         seed=seed,  # Random seed for reproducibility
         constraint_path = constraint_path if constraint else None,  # Path to restraints file
     )

--- a/germinal/filters/chai.py
+++ b/germinal/filters/chai.py
@@ -120,12 +120,17 @@ def run_chai(
     constraint = False
     if cdr3_idx is not None and hotspot_residue is not None:
         constraint = True
-        constraint_path = Path(__file__).with_name("chai.restraints")
-        rests_df = pd.read_csv(constraint_path)
+        # Read the master restraints template, populate per-run values, and
+        # write to a fresh copy inside tmp_dir. Never mutate the tracked
+        # source file — concurrent runs would otherwise race on it and
+        # corrupt a committed file.
+        master_restraints = Path(__file__).with_name("chai.restraints")
+        rests_df = pd.read_csv(master_restraints)
         rest_residue = binder_sequence[cdr3_idx]
         rests_df.loc[0, 'chainB'] = binder_chain
         rests_df.loc[0, 'res_idxB'] = f'{rest_residue}{cdr3_idx}'
         rests_df.loc[0, 'res_idxA'] = hotspot_residue
+        constraint_path = tmp_dir / "chai.restraints"
         rests_df.to_csv(constraint_path, index=False)
 
     # Run Chai-1 structure prediction with optimized parameters

--- a/germinal/filters/filter_utils.py
+++ b/germinal/filters/filter_utils.py
@@ -599,6 +599,9 @@ def run_structure_prediction(
             hotspot_residue = hotspot_residue,
             binder_chain=binder_chain,
             target_len=target_len,
+            num_trunk_recycles=run_settings.get("chai_num_trunk_recycles", 3),
+            num_diffn_timesteps=run_settings.get("chai_num_diffn_timesteps", 200),
+            use_esm_embeddings=run_settings.get("chai_use_esm_embeddings", True),
         )
     elif run_settings["structure_model"] == "protenix":
         external_pdb, external_metrics, ipsae = protenix.run_protenix(


### PR DESCRIPTION
## Summary

Two targeted fixes to \`germinal/filters/chai.py\`:

### 1. Stop mutating the tracked \`chai.restraints\` source file (P1 data race)

When \`cdr3_idx\` and \`hotspot_residue\` are both set, \`run_chai\` read the master \`germinal/filters/chai.restraints\` template into a DataFrame, populated per-run values, and **wrote the result back to the same tracked source path** via \`rests_df.to_csv(constraint_path, index=False)\`.

Two concrete problems:
- Concurrent chai runs race on the template. Whichever \`pd.read_csv\` lands last wins, and interleaved writes corrupt the file mid-load.
- The tracked file ends up carrying the most recent run's values in the working tree — any subsequent \`git commit\` accidentally captures random per-run data.

**Fix:** read the master template, populate in-memory, write the per-run CSV to \`tmp_dir / "chai.restraints"\`. \`tmp_dir\` is already hash-uniqued per run (\`generate_unique_hash()\`), so concurrent runs never collide and the tracked source file is never touched. \`run_inference\` receives a valid restraints path exactly as before.

### 2. Expose Chai inference knobs (configurability parity with AF3/Protenix)

\`run_chai\` hardcoded three \`run_inference()\` arguments:
- \`num_trunk_recycles=3\`
- \`num_diffn_timesteps=200\`
- \`use_esm_embeddings=True\`

These are legitimate speed/quality tradeoffs users want to tune per run. AF3 already exposes \`num_af3_seed\`; Protenix already exposes \`protenix_samples\`, \`protenix_cycles\`, \`protenix_steps\`. Chai was the only predictor with no knobs at all.

**Fix:**
- Add the three as optional kwargs on \`run_chai\`, defaulting to the previous hardcoded values so existing runs are unchanged.
- \`filter_utils.run_structure_prediction\` forwards them from \`run_settings\` via new keys \`chai_num_trunk_recycles\`, \`chai_num_diffn_timesteps\`, \`chai_use_esm_embeddings\`, each defaulting to the historical value when unset.

## Not included

- **\`device=\"cuda:0\"\` (line 137).** On reflection this is *not* a bug: in PyTorch, \`cuda:0\` respects \`CUDA_VISIBLE_DEVICES\` (the 0 indexes into the visible-device set). SLURM allocations work correctly as-is.
- **Return-tuple inconsistency** (Chai returns 2-tuple, AF3/Protenix return 3-tuple). The dispatcher in \`filter_utils.run_structure_prediction\` already initializes \`ipsae = None\` and downstream filters all have \`if ipsae is None\` guards (lines 213-219, 337, 350, 395). Nothing to fix here.

## Test plan

- [ ] Syntax check both touched files
- [ ] Run one job with \`structure_model: chai\` + constraints enabled, concurrently on two nodes — verify \`git status\` stays clean during and after
- [ ] Run one job with \`chai_num_trunk_recycles: 5\` in run config — verify Chai uses 5 not 3 (enable debug print / inspect \`run_inference\` call)
- [ ] Run one job with no Chai keys set — verify the three defaults kick in (3 / 200 / True)
- [ ] Spot-check that \`tmp_dir / \"chai.restraints\"\` exists during inference and is cleaned up afterward via the existing \`shutil.rmtree(str(tmp_dir))\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)