### PR TITLE
Fix generate_colabfold_msa crash on missing MSA + dedup CDR3 slicing

### DIFF
--- a/germinal/filters/af3.py
+++ b/germinal/filters/af3.py
@@ -280,19 +280,21 @@ def generate_colabfold_msa(sequence, design_name, output_dir, use_metagenomic_db
         return ""
 
     old_msa_path = os.path.join(output_dir, f"{design_name}_all", "uniref.a3m")
-    # Process MSA to ensure uniform sequence length for AF3 compatibility
-    remove_a3m_insertions(old_msa_path)
-    if os.path.exists(old_msa_path):
-        new_msa_path = os.path.join(output_dir, f"msas/{design_name}.a3m")
-        os.makedirs(os.path.dirname(new_msa_path), exist_ok=True)
-        shutil.copyfile(old_msa_path, new_msa_path)
-        shutil.rmtree(os.path.join(output_dir, f"{design_name}_all"))
-        return os.path.relpath(new_msa_path, output_dir)
-    else:
+    # Check existence before stripping insertions — on partial colabfold writes
+    # (timeout, network error, etc.) the file may be missing, and the strip call
+    # would crash with FileNotFoundError instead of falling back gracefully.
+    if not os.path.exists(old_msa_path):
         print(
             f"colabfold_search failed for {design_name}: MSA not found at {old_msa_path}. Falling back to no MSA."
         )
         return ""
+    # Process MSA to ensure uniform sequence length for AF3 compatibility
+    remove_a3m_insertions(old_msa_path)
+    new_msa_path = os.path.join(output_dir, f"msas/{design_name}.a3m")
+    os.makedirs(os.path.dirname(new_msa_path), exist_ok=True)
+    shutil.copyfile(old_msa_path, new_msa_path)
+    shutil.rmtree(os.path.join(output_dir, f"{design_name}_all"))
+    return os.path.relpath(new_msa_path, output_dir)
 
 
 def generate_msas(

--- a/germinal/filters/filter_utils.py
+++ b/germinal/filters/filter_utils.py
@@ -18,6 +18,27 @@ from germinal.filters import af3, chai, protenix, pDockQ, pyrosetta_utils
 from germinal.utils.io import IO, Trajectory
 
 
+def compute_cdr3_positions(run_settings: dict) -> list:
+    """Zero-indexed CDR-H3 positions, accounting for type (nb vs scfv) and vh_first.
+
+    For VL-first scFv the third CDR slot is L3; H3 sits in the second set of
+    CDRs, so we slice ``cdr_lengths[:2] : cdr_lengths[:3]``. For nb and
+    VH-first scFv the flat ``cdr_lengths[:-1]`` suffix lands on H3.
+    """
+    cdr_positions = run_settings["cdr_positions"]
+    cdr_lengths = run_settings["cdr_lengths"]
+    type_ = run_settings["type"].lower()
+    if type_ == "nb":
+        return cdr_positions[sum(cdr_lengths[:-1]):]
+    if type_ == "scfv":
+        if run_settings.get("vh_first", True):
+            return cdr_positions[sum(cdr_lengths[:2]):sum(cdr_lengths[:3])]
+        return cdr_positions[sum(cdr_lengths[:-1]):]
+    raise ValueError(
+        f"Type {run_settings['type']} not supported, select either nb or scfv"
+    )
+
+
 def run_filters(
     trajectory: Trajectory,
     run_settings: dict,
@@ -68,22 +89,7 @@ def run_filters(
         target_sequence.append(sequences_from_pdb[
             ch
         ])
-    # H-CDR3 positions (1-indexed). For VL-first scFv the third CDR slot is L3;
-    # H3 sits in the second set of CDRs. For nb and VH-first scFv the flat
-    # `cdr_lengths[:-1]` suffix lands on H3.
-    if run_settings["type"].lower() == "nb":
-        h3_positions = run_settings["cdr_positions"][sum(run_settings["cdr_lengths"][:-1]) :]
-    elif run_settings["type"].lower() == "scfv":
-        if run_settings.get("vh_first", True):
-            h3_positions = run_settings["cdr_positions"][
-                sum(run_settings["cdr_lengths"][:2]) : sum(run_settings["cdr_lengths"][:3])
-            ]
-        else:
-            h3_positions = run_settings["cdr_positions"][sum(run_settings["cdr_lengths"][:-1]) :]
-    else:
-        raise ValueError(
-            f"Type {run_settings['type']} not supported, select either nb or scfv"
-        )
+    h3_positions = compute_cdr3_positions(run_settings)
     cdr3 = np.array(h3_positions) + 1
 
     external_pdb, external_metrics, ipsae = run_structure_prediction(
@@ -621,17 +627,15 @@ def run_structure_prediction(
         )
     elif run_settings["structure_model"] == "chai":
 
-        # Use h3_positions computed by run_filters (PR #67 3-way branch
-        # correctly handles nb / VH-first scFv / VL-first scFv). The old
-        # hardcoded slice mis-sliced VL-first scFv runs (landed on H1/H2).
         # cdr3_idx passed to chai must be 1-indexed (PDB residue numbers,
         # matching the chai.restraints template format like "L13", "D108").
-        # h3_positions is 0-indexed, hence the +1.
-        if h3_positions is not None:
-            cdr3_idx = h3_positions[len(h3_positions)//2] + 1
-        else:
-            cdr3_idx = run_settings["cdr_positions"][run_settings["cdr_lengths"][0] + run_settings["cdr_lengths"][1]:]
-            cdr3_idx = cdr3_idx[len(cdr3_idx)//2] + 1
+        # compute_cdr3_positions returns 0-indexed, hence the +1. Reuse
+        # compute_cdr3_positions so the batch-fallback path (which enters here
+        # without h3_positions set by run_filters) gets the same 3-way branch
+        # and doesn't mis-slice VL-first scFv.
+        if h3_positions is None:
+            h3_positions = compute_cdr3_positions(run_settings)
+        cdr3_idx = h3_positions[len(h3_positions) // 2] + 1
 
         external_pdb, external_metrics = chai.run_chai(
             trajectory_sequence,

--- a/tests/test_compute_cdr3_positions.py
+++ b/tests/test_compute_cdr3_positions.py
@@ -1,0 +1,86 @@
+"""Tests for filter_utils.compute_cdr3_positions.
+
+Run under the germinal conda env:
+
+    source activate germinal
+    python tests/test_compute_cdr3_positions.py
+
+Targets the VL-first scFv regression that the old hardcoded
+`cdr_lengths[0] + cdr_lengths[1]:` slice in run_structure_prediction's chai
+fallback produced. The helper consolidates the 3-way branch so the bug cannot
+re-appear in either run_filters or the chai fallback.
+"""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from germinal.filters.filter_utils import compute_cdr3_positions
+
+
+class TestComputeCdr3Positions(unittest.TestCase):
+    def test_vl_first_scfv_slices_last_cdr(self):
+        """VL-first scFv: H3 is the last slot in cdr_positions."""
+        cdr_lengths = [5, 7, 11, 5, 17, 15]  # L1,L2,L3,H1,H2,H3
+        cdr_positions = list(range(sum(cdr_lengths)))
+        self.assertEqual(
+            compute_cdr3_positions({
+                "type": "scfv",
+                "vh_first": False,
+                "cdr_positions": cdr_positions,
+                "cdr_lengths": cdr_lengths,
+            }),
+            cdr_positions[45:],  # last 15
+        )
+
+    def test_vh_first_scfv_slices_middle_third(self):
+        """VH-first scFv: H3 sits at [H1+H2 : H1+H2+H3]."""
+        cdr_lengths = [5, 17, 15, 5, 7, 11]  # H1,H2,H3,L1,L2,L3
+        cdr_positions = list(range(sum(cdr_lengths)))
+        self.assertEqual(
+            compute_cdr3_positions({
+                "type": "scfv",
+                "vh_first": True,
+                "cdr_positions": cdr_positions,
+                "cdr_lengths": cdr_lengths,
+            }),
+            cdr_positions[22:37],
+        )
+
+    def test_nb_slices_last_cdr(self):
+        """Nanobody: flat CDR list, H3 is the last slot."""
+        cdr_lengths = [7, 6, 17]
+        cdr_positions = list(range(sum(cdr_lengths)))
+        self.assertEqual(
+            compute_cdr3_positions({
+                "type": "nb",
+                "cdr_positions": cdr_positions,
+                "cdr_lengths": cdr_lengths,
+            }),
+            cdr_positions[13:],
+        )
+
+    def test_vh_first_default_true(self):
+        """scFv without vh_first in config defaults to True."""
+        cdr_lengths = [5, 17, 15, 5, 7, 11]
+        cdr_positions = list(range(sum(cdr_lengths)))
+        got = compute_cdr3_positions({
+            "type": "scfv",
+            "cdr_positions": cdr_positions,
+            "cdr_lengths": cdr_lengths,
+        })
+        self.assertEqual(got, cdr_positions[22:37])
+
+    def test_unknown_type_raises(self):
+        with self.assertRaises(ValueError):
+            compute_cdr3_positions({
+                "type": "scab",
+                "cdr_positions": [1, 2, 3],
+                "cdr_lengths": [1, 1, 1],
+            })
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
Two small correctness fixes bundled into one PR.

### 1. `generate_colabfold_msa` crash on missing MSA (germinal/filters/af3.py)
`generate_colabfold_msa` previously called `remove_a3m_insertions(old_msa_path)` **before** checking `os.path.exists(old_msa_path)`. If `run_mmseqs2` returns without writing the expected file (partial ColabFold write, network timeout, etc.), this raises `FileNotFoundError` instead of falling back to the intended "no MSA" graceful path.

Reorder: existence check first, strip second. Net change: ~10 lines.

### 2. Complete CDR3 slicing dedup (germinal/filters/filter_utils.py)
Add `compute_cdr3_positions(run_settings)` helper as the single source of truth for the nb / VH-first scFv / VL-first scFv slicing. Two call sites:

- `run_filters` (line 87 today): had the 3-way branch inlined — replaced with the helper.
- `run_structure_prediction`'s chai fallback (line 639 today): **still had the pre-PR-#67 hardcoded `cdr_lengths[0]+cdr_lengths[1]:` slice**, which mis-slices VL-first scFv runs (lands on H1/H2 instead of H3). When batch prediction falls through to sequential `run_structure_prediction` for chai, `h3_positions` is `None`, so this buggy branch fires.

PR #67 fixed `run_filters` but missed this fallback. This PR closes that gap by routing both call sites through the helper.

## Test plan
- [x] New `tests/test_compute_cdr3_positions.py` — 5 unit tests covering nb, VH-first scFv, VL-first scFv, `vh_first` default, and unknown-type errors. All pass under `germinal` conda env.
- [x] `python -m py_compile germinal/filters/{af3,filter_utils}.py` — clean.
- [x] Validated on `cleanup/hunter-v1.5` against {AF3, Protenix} × {VHH, scFv} smoke matrix; zero errors across all jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)